### PR TITLE
default PR template is out of control, trim it down for this repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,39 +1,24 @@
-**Description:** Describe in a couple of sentences what this PR adds
-
 **JIRA:** Link to JIRA ticket
 
-**Dependencies:** dependencies on other outstanding PRs, issues, etc. 
+**Description:** Describe in a couple of sentences what this PR adds
+
+**Author concerns:** List any concerns about this PR - inelegant
+solutions, hacks, quick-and-dirty implementations, concerns about
+migrations, etc.
+
+**Dependencies:** dependencies on other outstanding PRs, issues, etc.
 
 **Merge deadline:** List merge deadline (if any)
 
-**Installation instructions:** List any non-trivial installation 
+**Installation instructions:** List any non-trivial installation
 instructions.
 
-**Testing instructions:**
-
-1. Open page A
-2. Do thing B
-3. Expect C to happen
-4. If D happened instead - check failed.
-
-**Reviewers:**
-- [ ] tag reviewer 
-- [ ] tag reviewer 
+**Testing instructions:** List any unusual instructions if a
+reviewer wishes to test locally.
 
 **Merge checklist:**
 - [ ] All reviewers approved
 - [ ] CI build is green
-- [ ] Version bumped
 - [ ] Changelog record added
 - [ ] Documentation updated (not only docstrings)
-- [ ] Commits are squashed
 
-**Post merge:**
-- [ ] Create a tag
-- [ ] Check new version is pushed to PyPI after tag-triggered build is 
-      finished.
-- [ ] Delete working branch (if not needed anymore)
-
-**Author concerns:** List any concerns about this PR - inelegant 
-solutions, hacks, quick-and-dirty implementations, concerns about 
-migrations, etc.


### PR DESCRIPTION
A long PR template with irrelevant parts ensures no one respects the
relevant parts. Trim out the pieces that don't apply to this repo
and move the most important parts to the top.