### PR TITLE
build: use a docker-compoase build directive rather than public image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  libmysqlclient-dev \
  libssl-dev \
  python3-dev \
+ build-essential \
  gcc
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
       dockerfile: Dockerfile
     container_name: program_intent_engagement.app
     volumes:
-      - .:/edx/app/program_intent_engagement/
-    command: bash -c 'while true; do python /edx/app/program_intent_engagement/manage.py runserver 0.0.0.0:18781; sleep 2; done'
+      - .:/edx/app/program-intent-engagement
+    command: bash -c 'while true; do python /edx/app/program-intent-engagement/manage.py runserver 0.0.0.0:18781; sleep 2; done'
     environment:
       DJANGO_SETTINGS_MODULE: program_intent_engagement.settings.devstack
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,10 @@ services:
 
   app:
     # Uncomment this line to use the official program_intent_engagement base image
-    image: openedx/program_intent_engagement
-
+    # image: openedx/program_intent_engagement
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: program_intent_engagement.app
     volumes:
       - .:/edx/app/program_intent_engagement/


### PR DESCRIPTION
## Description

I've been volunteering to help interns with devstack/hosted-devstack and noticed a few tweaks to this project's docker setup that might make life easier.

- official docker image is unpublished or non-public so `make dev.up` fails
- other apps use a docker-compose.yml build directive, like so https://github.com/openedx/edx-enterprise/blob/master/docker-compose.yml#L6-L8
- making some mounts/paths consisent
