### PR TITLE
build: adding a venv to the Dockerfile for flexibiltiy/consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,10 @@ RUN python3.8 -m venv $VIRTUAL_ENV
 
 # Copy the requirements explicitly even though we copy everything below
 # this prevents the image cache from busting unless the dependencies have changed.
-COPY requirements/production.txt /edx/app/program-intent-engagement/requirements/production.txt
+COPY requirements/ /edx/app/program-intent-engagement/requirements/
 
 # Dependencies are installed as root so they cannot be modified by the application user.
-RUN pip install -r requirements/production.txt
+RUN pip install -r requirements/dev.txt
 
 RUN mkdir -p /edx/var/log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,13 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  locales \
  python3.8 \
  python3-pip \
+ python3.8-venv \
  libmysqlclient-dev \
  libssl-dev \
  python3-dev \
  build-essential \
- gcc
+ gcc \
+ git
 
 
 RUN pip install --upgrade pip setuptools
@@ -45,10 +47,15 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV DJANGO_SETTINGS_MODULE program_intent_engagement.settings.production
 
+ENV VIRTUAL_ENV='/edx/app/venvs/program-intent-engagement'
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 EXPOSE 18781
 RUN useradd -m --shell /bin/false app
 
 WORKDIR /edx/app/program-intent-engagement
+
+RUN python3.8 -m venv $VIRTUAL_ENV
 
 # Copy the requirements explicitly even though we copy everything below
 # this prevents the image cache from busting unless the dependencies have changed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  libssl-dev \
  python3-dev \
  build-essential \
- gcc \
  git
 
 


### PR DESCRIPTION
## Description

The cookie-cutter seems to produce a fairly sparse Dockerfile. One of the missing features is a venv which is commonly found in other edX projects - such as edx-enterprise. Having this venv isnt strictly required (given docker) but adds some flexibility and consistency.

## Testing

- I built and ran this with @m-pitera 