### PR TITLE
fix: update default value for migration

### DIFF
--- a/program_intent_engagement/apps/core/migrations/0004_programintent_lms_user_id.py
+++ b/program_intent_engagement/apps/core/migrations/0004_programintent_lms_user_id.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='programintent',
             name='lms_user_id',
-            field=models.IntegerField(db_index=True, default=10000000000000000000),
+            field=models.IntegerField(db_index=True, default=-1),
         ),
         migrations.AlterUniqueTogether(
             name='programintent',


### PR DESCRIPTION
The default value for the migration was too large, so it should be updated to a smaller value. The migrations have not been successfully applied on stage or prod, and there is also no data in stage or prod yet.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)

