### PR TITLE
chore: update PIE docs to remove intent reason

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -20,8 +20,6 @@ The types of intent reasons and their corresponding certainty are described in t
 +----------------------+--------------------------------------------+-------------+
 | ENROLLED_ALL_COURSES | User has enrolled in all program courses   | MAYBE       |
 +----------------------+--------------------------------------------+-------------+
-| EARNED_PROGRAM_CERT  | User has earned a program certificate      | CERTAIN_YES |
-+----------------------+--------------------------------------------+-------------+
 
 While these are the current intent reasons, users have the ability to add more if needed. It should also
 be noted that users also have the ability to add an intent with a `CERTAIN_NO` certainty, although none of


### PR DESCRIPTION
Earning a program certificate has been [removed as an intent reason in the DBT model](https://github.com/edx/warehouse-transforms/pull/3366), so we should also remove it here.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)

