### PR TITLE
fix: align pie urls with each other and edX standards

### DIFF
--- a/program_intent_engagement/apps/api/v1/urls.py
+++ b/program_intent_engagement/apps/api/v1/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
         name="program_intent-insert",
     ),
     re_path(
-        r"^intents/most-recent-and-certain?$",
+        r"^program_intents/most_recent_and_certain?$",
         MostRecentAndCertainIntentsView.as_view(),
         name="intents-list",
     ),

--- a/program_intent_engagement/apps/api/v1/views.py
+++ b/program_intent_engagement/apps/api/v1/views.py
@@ -79,7 +79,7 @@ class MostRecentAndCertainIntentsView(APIView):
     This endpoint returns a list of intents specified by the user.
       Grouped by programs and sorted by most recent
       and CERTAIN (if available, otherwise MAYBE) intent
-    Path: /api/[version]/intents/most-recent-and-certain
+    Path: /api/[version]/program_intents/most_recent_and_certain
     Returns:
      * 200: OK, list of intents
      * 404: User not found


### PR DESCRIPTION
we prefer under_scores and let's call them both program_intents

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Documentation updated (not only docstrings)

