### PR TITLE
fix MostRecentAndCertainIntentsView

### DIFF
--- a/program_intent_engagement/apps/api/v1/views.py
+++ b/program_intent_engagement/apps/api/v1/views.py
@@ -2,6 +2,7 @@
 V1 API Views
 """
 from itertools import groupby
+from operator import itemgetter
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import status
@@ -112,12 +113,16 @@ class MostRecentAndCertainIntentsView(APIView):
         ):
             intents = list(intents)
 
-            # sort by certainty, effective_timestamp
+            # sort by effective_timestamp descending, then certainty ascending
+            intents.sort(
+                key=itemgetter("effective_timestamp"),
+                reverse=True,
+            )
+
             intents.sort(
                 key=lambda x: (
                     certainty_order[(x["certainty"])],
-                    x["effective_timestamp"],
-                )
+                ),
             )
 
             # grab the top intent


### PR DESCRIPTION
**JIRA:** [MST-1595](https://2u-internal.atlassian.net/browse/MST-1595)

**Description:** This PR fixes the MostRecentAndCertainIntentsView so that the most recent intent is returned (because of ascending sort). It also added a test to cover this case.

**Author concerns:** The way I resolved this is using [this approach via stack overflow](https://stackoverflow.com/questions/6666748/sort-list-of-lists-ascending-and-then-descending). I like that it still uses the sort function and looks clean but I'm worried it's not as readable. This could be resolved through better comments/documentation or by manually sorting (performance?). Updated approach [chaining multiple sorts](https://docs.python.org/3/howto/sorting.html#sort-stability-and-complex-sorts).

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green

