### PR TITLE
fix: return 401 when there is no user for intents instead of erroring out

### DIFF
--- a/program_intent_engagement/apps/api/v1/tests/test_views.py
+++ b/program_intent_engagement/apps/api/v1/tests/test_views.py
@@ -177,6 +177,14 @@ class ProgramIntentRecentAndCertainViewTests(ProgramIntentAPITestCase):
         response = self.get_api(user)
         return response
 
+    def test_no_user(self):
+        """
+        Test that if there is no logged in user we get the appropriate 401
+        """
+        url = reverse("api:v1:intents-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
     def test_user_no_intents(self):
         """
         Test that when user has no program intents you get 200 ok response with an empty list

--- a/program_intent_engagement/apps/api/v1/views.py
+++ b/program_intent_engagement/apps/api/v1/views.py
@@ -139,6 +139,9 @@ class MostRecentAndCertainIntentsView(APIView):
         or the most recent MAYBE intent if a CERTAIN intent does not exist.
         """
 
+        # test that user is populated is not enough, the anonymous user exists but has no lms ID
+        if not self.request.user or not hasattr(self.request.user, "lms_user_id"):
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
         lms_user_id = self.request.user.lms_user_id
 
         user_intents = ProgramIntent.objects.filter(lms_user_id=lms_user_id)


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/MST-1604

If there is no user, 401 unauthorized instead of blowing up on lack of user.

Of course it's not quite that simple because there is a fake user, so we have to handle that.

Also smoke tested locally via browser in the negative 401 case, bringing my devstack back up to snuff to validate the logged in case as well.