### PR TITLE
fix: add constraints file to test.in to fix upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.5.2
     # via django
-certifi==2022.9.24
+certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via
@@ -25,7 +25,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   pyjwt
     #   social-auth-core
@@ -107,7 +107,7 @@ markupsafe==2.1.1
     # via jinja2
 mysqlclient==2.1.1
     # via -r requirements/base.in
-newrelic==8.4.0
+newrelic==8.5.0
     # via edx-django-utils
 oauthlib==3.2.2
     # via
@@ -115,7 +115,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.3
+packaging==22.0
     # via drf-yasg
 pbr==5.11.0
     # via stevedore
@@ -123,7 +123,7 @@ psutil==5.9.4
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -138,8 +138,6 @@ pymongo==3.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
-pyparsing==3.0.9
-    # via packaging
 python-dateutil==2.8.2
     # via edx-drf-extensions
 python3-openid==3.2.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2022.9.24
+certifi==2022.12.7
     # via requests
 charset-normalizer==2.1.1
     # via requests
@@ -14,22 +14,20 @@ coverage==6.5.0
     # via codecov
 distlib==0.3.6
     # via virtualenv
-filelock==3.8.0
+filelock==3.8.2
     # via
     #   tox
     #   virtualenv
 idna==3.4
     # via requests
-packaging==21.3
+packaging==22.0
     # via tox
-platformdirs==2.5.4
+platformdirs==2.6.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.9
-    # via packaging
 requests==2.28.1
     # via codecov
 six==1.16.0
@@ -37,8 +35,10 @@ six==1.16.0
 tomli==2.0.1
     # via tox
 tox==3.27.1
-    # via -r requirements/ci.in
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/ci.in
 urllib3==1.26.13
     # via requests
-virtualenv==20.16.7
+virtualenv==20.17.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,7 +25,7 @@ build==0.9.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   -r requirements/validation.txt
     #   requests
@@ -34,7 +34,7 @@ cffi==1.15.1
     #   -r requirements/validation.txt
     #   cryptography
     #   pynacl
-chardet==5.0.0
+chardet==5.1.0
     # via diff-cover
 charset-normalizer==2.1.1
     # via
@@ -76,11 +76,10 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/validation.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
 ddt==1.6.0
     # via -r requirements/validation.txt
@@ -89,7 +88,7 @@ defusedxml==0.7.1
     #   -r requirements/validation.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==7.0.2
+diff-cover==7.3.0
     # via -r requirements/dev.in
 dill==0.3.6
     # via
@@ -122,7 +121,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
-django-debug-toolbar==3.7.0
+django-debug-toolbar==3.8.1
     # via -r requirements/dev.in
 django-dynamic-fixture==3.1.2
     # via -r requirements/validation.txt
@@ -186,11 +185,11 @@ exceptiongroup==1.0.4
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==15.3.3
+faker==15.3.4
     # via
     #   -r requirements/validation.txt
     #   factory-boy
-filelock==3.8.0
+filelock==3.8.2
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -228,11 +227,6 @@ jaraco-classes==3.2.3
     # via
     #   -r requirements/validation.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/validation.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/validation.txt
@@ -263,7 +257,7 @@ more-itertools==9.0.0
     #   jaraco-classes
 mysqlclient==2.1.1
     # via -r requirements/validation.txt
-newrelic==8.4.0
+newrelic==8.5.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -276,7 +270,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
-packaging==21.3
+packaging==22.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/validation.txt
@@ -284,7 +278,7 @@ packaging==21.3
     #   drf-yasg
     #   pytest
     #   tox
-path==16.5.0
+path==16.6.0
     # via edx-i18n-tools
 pbr==5.11.0
     # via
@@ -294,13 +288,13 @@ pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pip-tools==6.10.0
+pip-tools==6.11.0
     # via -r requirements/pip-tools.txt
-pkginfo==1.8.3
+pkginfo==1.9.2
     # via
     #   -r requirements/validation.txt
     #   twine
-platformdirs==2.5.4
+platformdirs==2.6.0
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -327,7 +321,7 @@ pycparser==2.21
     # via
     #   -r requirements/validation.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/validation.txt
     #   pyjwkest
@@ -351,7 +345,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.6
+pylint==2.15.8
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -379,11 +373,6 @@ pynacl==1.5.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
-pyparsing==3.0.9
-    # via
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/validation.txt
-    #   packaging
 pytest==7.2.0
     # via
     #   -r requirements/validation.txt
@@ -458,10 +447,6 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/validation.txt
     #   ruamel-yaml
-secretstorage==3.3.3
-    # via
-    #   -r requirements/validation.txt
-    #   keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt
@@ -530,14 +515,13 @@ tomlkit==0.11.6
     #   pylint
 tox==3.27.1
     # via -r requirements/validation.txt
-twine==4.0.1
+twine==4.0.2
     # via -r requirements/validation.txt
 typing-extensions==4.4.0
     # via
     #   -r requirements/validation.txt
     #   astroid
     #   pylint
-    #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/validation.txt
@@ -548,7 +532,7 @@ urllib3==1.26.13
     #   -r requirements/validation.txt
     #   requests
     #   twine
-virtualenv==20.16.7
+virtualenv==20.17.1
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -564,7 +548,7 @@ wrapt==1.14.1
     # via
     #   -r requirements/validation.txt
     #   astroid
-zipp==3.10.0
+zipp==3.11.0
     # via
     #   -r requirements/validation.txt
     #   importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -25,7 +25,7 @@ bleach==5.0.1
     # via readme-renderer
 build==0.9.0
     # via -r requirements/doc.in
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   -r requirements/test.txt
     #   requests
@@ -70,11 +70,10 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
 ddt==1.6.0
     # via -r requirements/test.txt
@@ -179,11 +178,11 @@ exceptiongroup==1.0.4
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==15.3.3
+faker==15.3.4
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.8.0
+filelock==3.8.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -221,10 +220,6 @@ itypes==1.2.0
     #   coreapi
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -251,7 +246,7 @@ more-itertools==9.0.0
     # via jaraco-classes
 mysqlclient==2.1.1
     # via -r requirements/test.txt
-newrelic==8.4.0
+newrelic==8.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -264,7 +259,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-packaging==21.3
+packaging==22.0
     # via
     #   -r requirements/test.txt
     #   build
@@ -278,9 +273,9 @@ pbr==5.11.0
     #   stevedore
 pep517==0.13.0
     # via build
-pkginfo==1.8.3
+pkginfo==1.9.2
     # via twine
-platformdirs==2.5.4
+platformdirs==2.6.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -302,7 +297,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -324,7 +319,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.6
+pylint==2.15.8
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -352,10 +347,6 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pyparsing==3.0.9
-    # via
-    #   -r requirements/test.txt
-    #   packaging
 pytest==7.2.0
     # via
     #   -r requirements/test.txt
@@ -425,8 +416,6 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/test.txt
     #   ruamel-yaml
-secretstorage==3.3.3
-    # via keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
@@ -509,15 +498,16 @@ tomlkit==0.11.6
     #   -r requirements/test.txt
     #   pylint
 tox==3.27.1
-    # via -r requirements/test.txt
-twine==4.0.1
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/test.txt
+twine==4.0.2
     # via -r requirements/doc.in
 typing-extensions==4.4.0
     # via
     #   -r requirements/test.txt
     #   astroid
     #   pylint
-    #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
@@ -528,7 +518,7 @@ urllib3==1.26.13
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.16.7
+virtualenv==20.17.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -538,5 +528,5 @@ wrapt==1.14.1
     # via
     #   -r requirements/test.txt
     #   astroid
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,14 +8,12 @@ build==0.9.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==21.3
+packaging==22.0
     # via build
 pep517==0.13.0
     # via build
-pip-tools==6.10.0
+pip-tools==6.11.0
     # via -r requirements/pip-tools.in
-pyparsing==3.0.9
-    # via packaging
 tomli==2.0.1
     # via
     #   build

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,7 +8,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -36,7 +36,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -147,7 +147,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
-newrelic==8.4.0
+newrelic==8.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -160,7 +160,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-packaging==21.3
+packaging==22.0
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -176,7 +176,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -200,10 +200,6 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pyparsing==3.0.9
-    # via
-    #   -r requirements/base.txt
-    #   packaging
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -19,7 +19,7 @@ attrs==22.1.0
     #   pytest
 bleach==5.0.1
     # via readme-renderer
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   -r requirements/test.txt
     #   requests
@@ -64,11 +64,10 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
 ddt==1.6.0
     # via -r requirements/test.txt
@@ -167,11 +166,11 @@ exceptiongroup==1.0.4
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==15.3.3
+faker==15.3.4
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.8.0
+filelock==3.8.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -207,10 +206,6 @@ itypes==1.2.0
     #   coreapi
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -236,7 +231,7 @@ more-itertools==9.0.0
     # via jaraco-classes
 mysqlclient==2.1.1
     # via -r requirements/test.txt
-newrelic==8.4.0
+newrelic==8.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -249,7 +244,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-packaging==21.3
+packaging==22.0
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -259,9 +254,9 @@ pbr==5.11.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pkginfo==1.8.3
+pkginfo==1.9.2
     # via twine
-platformdirs==2.5.4
+platformdirs==2.6.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -285,7 +280,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -307,7 +302,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.6
+pylint==2.15.8
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -335,10 +330,6 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pyparsing==3.0.9
-    # via
-    #   -r requirements/test.txt
-    #   packaging
 pytest==7.2.0
     # via
     #   -r requirements/test.txt
@@ -404,8 +395,6 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/test.txt
     #   ruamel-yaml
-secretstorage==3.3.3
-    # via keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
@@ -467,15 +456,16 @@ tomlkit==0.11.6
     #   -r requirements/test.txt
     #   pylint
 tox==3.27.1
-    # via -r requirements/test.txt
-twine==4.0.1
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/test.txt
+twine==4.0.2
     # via -r requirements/quality.in
 typing-extensions==4.4.0
     # via
     #   -r requirements/test.txt
     #   astroid
     #   pylint
-    #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
@@ -486,7 +476,7 @@ urllib3==1.26.13
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.16.7
+virtualenv==20.17.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -496,5 +486,5 @@ wrapt==1.14.1
     # via
     #   -r requirements/test.txt
     #   astroid
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,4 +1,5 @@
 # Requirements for test runs.
+-c constraints.txt
 
 -r base.txt               # Core dependencies for this package
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ astroid==2.12.13
     #   pylint-celery
 attrs==22.1.0
     # via pytest
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -55,7 +55,7 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -72,6 +72,7 @@ dill==0.3.6
 distlib==0.3.6
     # via virtualenv
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   django-cors-headers
     #   django-crum
@@ -145,9 +146,9 @@ exceptiongroup==1.0.4
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==15.3.3
+faker==15.3.4
     # via factory-boy
-filelock==3.8.0
+filelock==3.8.2
     # via
     #   tox
     #   virtualenv
@@ -188,7 +189,7 @@ mock==4.0.3
     # via -r requirements/test.in
 mysqlclient==2.1.1
     # via -r requirements/base.txt
-newrelic==8.4.0
+newrelic==8.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -201,7 +202,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-packaging==21.3
+packaging==22.0
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -211,7 +212,7 @@ pbr==5.11.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.5.4
+platformdirs==2.6.0
     # via
     #   pylint
     #   virtualenv
@@ -229,7 +230,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -245,7 +246,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.6
+pylint==2.15.8
     # via
     #   edx-lint
     #   pylint-celery
@@ -267,10 +268,6 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pyparsing==3.0.9
-    # via
-    #   -r requirements/base.txt
-    #   packaging
 pytest==7.2.0
     # via
     #   pytest-cov
@@ -376,7 +373,9 @@ tomli==2.0.1
 tomlkit==0.11.6
     # via pylint
 tox==3.27.1
-    # via -r requirements/test.in
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/test.in
 typing-extensions==4.4.0
     # via
     #   astroid
@@ -390,7 +389,7 @@ urllib3==1.26.13
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.16.7
+virtualenv==20.17.1
     # via tox
 wrapt==1.14.1
     # via astroid

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -24,7 +24,7 @@ bleach==5.0.1
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -80,12 +80,11 @@ coverage[toml]==6.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
 ddt==1.6.0
     # via
@@ -221,12 +220,12 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==15.3.3
+faker==15.3.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.8.0
+filelock==3.8.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -271,11 +270,6 @@ jaraco-classes==3.2.3
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
@@ -313,7 +307,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-newrelic==8.4.0
+newrelic==8.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -329,7 +323,7 @@ openapi-codec==1.3.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
-packaging==21.3
+packaging==22.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -341,11 +335,11 @@ pbr==5.11.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   stevedore
-pkginfo==1.8.3
+pkginfo==1.9.2
     # via
     #   -r requirements/quality.txt
     #   twine
-platformdirs==2.5.4
+platformdirs==2.6.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -374,7 +368,7 @@ pycparser==2.21
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -400,7 +394,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.6
+pylint==2.15.8
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -434,11 +428,6 @@ pynacl==1.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-pyparsing==3.0.9
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   packaging
 pytest==7.2.0
     # via
     #   -r requirements/quality.txt
@@ -526,10 +515,6 @@ ruamel-yaml-clib==0.2.7
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   ruamel-yaml
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/quality.txt
@@ -607,7 +592,7 @@ tox==3.27.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-twine==4.0.1
+twine==4.0.2
     # via -r requirements/quality.txt
 typing-extensions==4.4.0
     # via
@@ -615,7 +600,6 @@ typing-extensions==4.4.0
     #   -r requirements/test.txt
     #   astroid
     #   pylint
-    #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt
@@ -628,7 +612,7 @@ urllib3==1.26.13
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.16.7
+virtualenv==20.17.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -642,7 +626,7 @@ wrapt==1.14.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-zipp==3.10.0
+zipp==3.11.0
     # via
     #   -r requirements/quality.txt
     #   importlib-metadata


### PR DESCRIPTION
The [latest run of the upgrade requirements](https://github.com/edx/program-intent-engagement/actions/runs/3664782086/jobs/6195417899) workflow failed due to a new constraint on tox that was not carried down to the testing requirements. I've updated `test.in` to include the constraints file and also ran `make upgrade` successfully. 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)

