### PR TITLE
fix: install pkg-config dependency for mysqlclient>=2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ MAINTAINER sre@edx.org
 # libmysqlclient-dev; to install header files needed to use native C implementation for
 # MySQL-python for performance gains.
 
+# pkg-config; mysqlclient>=2.2.0 requires pkg-config (https://github.com/PyMySQL/mysqlclient/issues/620)
+
 # libssl-dev; # mysqlclient wont install without this.
 
 # python3-dev; to install header files for python extensions; much wheel-building depends on this
@@ -27,6 +29,7 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  python3.8 \
  python3-pip \
  libmysqlclient-dev \
+ pkg-config \
  libssl-dev \
  python3-dev \
  build-essential \


### PR DESCRIPTION
**JIRA:** None.

**Description:**

Repositiories that depend on mysqlclient>=2.2.0 will need to install the package pkg-config in their Dockerfile: https://github.com/PyMySQL/mysqlclient/issues/620. This commit installs the pkg-config package in the Dockerfile.

If this is missing, then pip install of mysqlclient fails with an error that includes the following:

```
Exception: Can not find valid pkg-config name.
Specify MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS env vars manually
```

See https://github.com/edx/edx-arch-experiments/issues/349.

**Author concerns:** None.

**Dependencies:** None.

**Installation instructions:** None.

**Testing instructions:**

Build the Dockerfile using `docker build -f Dockerfile .`.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)

