### PR TITLE
build: Remove pycrypto system lib deletion hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,7 @@ piptools: ## install pinned version of pip-compile and pip-sync
 	pip install -r requirements/pip.txt
 	pip install -r requirements/pip-tools.txt
 
-clean_pycrypto: ## temporary (?) hack to deal with the pycrypto dep that's installed via setup-tools
-	ls -d /usr/lib/python3/dist-packages/* | grep 'pycrypto\|pygobject\|pyxdg' | xargs rm -f
-
-requirements: clean_pycrypto piptools dev_requirements ## sync to default requirements
+requirements: piptools dev_requirements ## sync to default requirements
 
 ci_requirements: validation_requirements ## sync to requirements needed for CI checks
 


### PR DESCRIPTION
It's not clear what this was for, but it's probably not needed and doesn't seem like it would work anyhow. (And it's making `make requirements` fail.)

Part of https://github.com/edx/edx-arch-experiments/issues/391
