### PR TITLE
feat: remove JWT_AUTH_REFRESH_COOKIE

### DIFF
--- a/program_intent_engagement/settings/base.py
+++ b/program_intent_engagement/settings/base.py
@@ -223,7 +223,6 @@ JWT_AUTH = {
     'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
 }
 
 # Carry fields from the JWT token and LMS user into the local user


### PR DESCRIPTION
**Description:**
The setting JWT_AUTH_REFRESH_COOKIE is meaningless and unused and should be cleaned up to avoid confusion.
In the very early days of introducing MFEs, we thought we were going to need this cookie in addition to the JWT cookie. However, it turned out we didn't need it, but the setting stuck around the contagion of it (being in cookiecutter and other template libraries) has resulted in it uselessly being copied to many repos.

**Supporting information:**
as per the original ticket https://github.com/openedx/public-engineering/issues/190, this setting is removed.

**Rationale**
The setting JWT_AUTH_REFRESH_COOKIE is meaningless and unused, and should be cleaned up to avoid confusion.

In the very early days of introducing MFEs, we thought we were going to need this cookie in addition to the JWT cookie. However, it turned out we didn't need it, but the setting stuck around the contagion of it (being in cookiecutter and other template libraries) has resulted in it uselessly being copied to many repos.

**Removal**
The setting JWT_AUTH_REFRESH_COOKIE can simply be removed with no ramifications.