### PR TITLE
fix: remove JWT_AUTH_REFRESH_COOKIE

### DIFF
--- a/program_intent_engagement/settings/base.py
+++ b/program_intent_engagement/settings/base.py
@@ -223,7 +223,6 @@ JWT_AUTH = {
     'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
 }
 
 # Carry fields from the JWT token and LMS user into the local user


### PR DESCRIPTION
**Description:**

Remove unused JWT_AUTH_REFRESH_COOKIE setting. This setting was never actually used, so there is no timing issues.

See DEPR for details:
https://github.com/openedx/public-engineering/issues/190