### PR TITLE
chore: fixing the open API schema generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# it's easier to develop when the dockerfile is local but it doesn't belong in the repository
+Dockerfile
+
 *.py[cod]
 
 *.log

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,11 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
 python:
-  version: 3.12
   install:
     - requirements: requirements/doc.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -519,7 +519,7 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.8', None),
+    'python': ('https://docs.python.org/3.12', None),
 }
 
 

--- a/program_intent_engagement/settings/base.py
+++ b/program_intent_engagement/settings/base.py
@@ -14,7 +14,7 @@ def root(*path_fragments):
 
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('PROGRAM_INTENT_ENGAGEMENT_SECRET_KEY', 'insecure-secret-key')
+SECRET_KEY = os.environ.get("PROGRAM_INTENT_ENGAGEMENT_SECRET_KEY", "insecure-secret-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
@@ -23,97 +23,92 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
-INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'release_util',
-)
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "release_util",
+]
 
-THIRD_PARTY_APPS = (
-    'corsheaders',
-    'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens
-    'rest_framework',
-    'rest_framework_swagger',
-    'social_django',
-    'waffle',
-)
+THIRD_PARTY_APPS = [
+    "corsheaders",
+    "csrf.apps.CsrfAppConfig",  # Enables frontend apps to retrieve CSRF tokens
+    "rest_framework",
+    "social_django",
+    "waffle",
+]
 
-PROJECT_APPS = (
-    'program_intent_engagement.apps.core',
-    'program_intent_engagement.apps.api',
-)
+PROJECT_APPS = [
+    "program_intent_engagement.apps.core",
+    "program_intent_engagement.apps.api",
+]
 
 INSTALLED_APPS += THIRD_PARTY_APPS
 INSTALLED_APPS += PROJECT_APPS
 
 MIDDLEWARE = (
     # Resets RequestCache utility for added safety.
-    'edx_django_utils.cache.middleware.RequestCacheMiddleware',
-
+    "edx_django_utils.cache.middleware.RequestCacheMiddleware",
     # Monitoring middleware should be immediately after RequestCacheMiddleware
-    'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',  # python and django version
-    'edx_django_utils.monitoring.CookieMonitoringMiddleware',  # cookie names (compliance) and sizes
-    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',  # support accumulate & increment
-    'edx_django_utils.monitoring.MonitoringMemoryMiddleware',  # memory usage
-
-    'corsheaders.middleware.CorsMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'social_django.middleware.SocialAuthExceptionMiddleware',
-    'waffle.middleware.WaffleMiddleware',
+    "edx_django_utils.monitoring.DeploymentMonitoringMiddleware",  # python and django version
+    "edx_django_utils.monitoring.CookieMonitoringMiddleware",  # cookie names (compliance) and sizes
+    "edx_django_utils.monitoring.CachedCustomMonitoringMiddleware",  # support accumulate & increment
+    "edx_django_utils.monitoring.MonitoringMemoryMiddleware",  # memory usage
+    "corsheaders.middleware.CorsMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "social_django.middleware.SocialAuthExceptionMiddleware",
+    "waffle.middleware.WaffleMiddleware",
     # Enables force_django_cache_miss functionality for TieredCache.
-    'edx_django_utils.cache.middleware.TieredCacheMiddleware',
+    "edx_django_utils.cache.middleware.TieredCacheMiddleware",
     # Outputs monitoring metrics for a request.
-    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    "edx_rest_framework_extensions.middleware.RequestMetricsMiddleware",
     # Ensures proper DRF permissions in support of JWTs
-    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    "edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware",
 )
 
 # Enable CORS
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_HEADERS = corsheaders_default_headers + (
-    'use-jwt-cookie',
-)
+CORS_ALLOW_HEADERS = corsheaders_default_headers + ("use-jwt-cookie",)
 CORS_ORIGIN_WHITELIST = []
 
-ROOT_URLCONF = 'program_intent_engagement.urls'
+ROOT_URLCONF = "program_intent_engagement.urls"
 
 # Python dotted path to the WSGI application used by Django's runserver.
-WSGI_APPLICATION = 'program_intent_engagement.wsgi.application'
+WSGI_APPLICATION = "program_intent_engagement.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 # Set this value in the environment-specific files (e.g. local.py, production.py, test.py)
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.',
-        'NAME': '',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '',  # Set to empty string for default.
+    "default": {
+        "ENGINE": "django.db.backends.",
+        "NAME": "",
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",  # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
+        "PORT": "",  # Set to empty string for default.
     }
 }
 
 # New DB primary keys default to an IntegerField.
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -121,55 +116,49 @@ USE_L10N = True
 
 USE_TZ = True
 
-LOCALE_PATHS = (
-    root('conf', 'locale'),
-)
+LOCALE_PATHS = (root("conf", "locale"),)
 
 
 # MEDIA CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-root
-MEDIA_ROOT = root('media')
+MEDIA_ROOT = root("media")
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-url
-MEDIA_URL = '/media/'
+MEDIA_URL = "/media/"
 # END MEDIA CONFIGURATION
 
 
 # STATIC FILE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-root
-STATIC_ROOT = root('assets')
+STATIC_ROOT = root("assets")
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#static-url
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
-STATICFILES_DIRS = (
-    root('static'),
-)
+STATICFILES_DIRS = (root("static"),)
 
 # TEMPLATE CONFIGURATION
 # See: https://docs.djangoproject.com/en/3.2/ref/settings/#templates
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-        'DIRS': (
-            root('templates'),
-        ),
-        'OPTIONS': {
-            'context_processors': (
-                'django.contrib.auth.context_processors.auth',
-                'django.template.context_processors.debug',
-                'django.template.context_processors.i18n',
-                'django.template.context_processors.media',
-                'django.template.context_processors.request',
-                'django.template.context_processors.static',
-                'django.template.context_processors.tz',
-                'django.contrib.messages.context_processors.messages',
-                'program_intent_engagement.apps.core.context_processors.core',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "DIRS": (root("templates"),),
+        "OPTIONS": {
+            "context_processors": (
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.request",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+                "program_intent_engagement.apps.core.context_processors.core",
             ),
-            'debug': True,  # Django will only display debug pages if the global DEBUG setting is set to True.
-        }
+            "debug": True,  # Django will only display debug pages if the global DEBUG setting is set to True.
+        },
     },
 ]
 # END TEMPLATE CONFIGURATION
@@ -179,50 +168,50 @@ TEMPLATES = [
 # The purpose of customizing the cookie names is to avoid conflicts when
 # multiple Django services are running behind the same hostname.
 # Detailed information at: https://docs.djangoproject.com/en/dev/ref/settings/
-SESSION_COOKIE_NAME = 'program_intent_engagement_sessionid'
-CSRF_COOKIE_NAME = 'program_intent_engagement_csrftoken'
-LANGUAGE_COOKIE_NAME = 'program_intent_engagement_language'
+SESSION_COOKIE_NAME = "program_intent_engagement_sessionid"
+CSRF_COOKIE_NAME = "program_intent_engagement_csrftoken"
+LANGUAGE_COOKIE_NAME = "program_intent_engagement_language"
 # END COOKIE CONFIGURATION
 
 CSRF_COOKIE_SECURE = False
 CSRF_TRUSTED_ORIGINS = []
 
 # AUTHENTICATION CONFIGURATION
-LOGIN_URL = '/login/'
-LOGOUT_URL = '/logout/'
+LOGIN_URL = "/login/"
+LOGOUT_URL = "/logout/"
 
-AUTH_USER_MODEL = 'core.User'
+AUTH_USER_MODEL = "core.User"
 
 AUTHENTICATION_BACKENDS = (
-    'auth_backends.backends.EdXOAuth2',
-    'django.contrib.auth.backends.ModelBackend',
+    "auth_backends.backends.EdXOAuth2",
+    "django.contrib.auth.backends.ModelBackend",
 )
 
 ENABLE_AUTO_AUTH = False
-AUTO_AUTH_USERNAME_PREFIX = 'auto_auth_'
+AUTO_AUTH_USERNAME_PREFIX = "auto_auth_"
 
-SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
+SOCIAL_AUTH_STRATEGY = "auth_backends.strategies.EdxDjangoStrategy"
 
 # Set these to the correct values for your OAuth2 provider (e.g., LMS)
-SOCIAL_AUTH_EDX_OAUTH2_KEY = 'replace-me'
-SOCIAL_AUTH_EDX_OAUTH2_SECRET = 'replace-me'
-SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = 'replace-me'
-SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = 'replace-me'
-BACKEND_SERVICE_EDX_OAUTH2_KEY = 'replace-me'
-BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'replace-me'
+SOCIAL_AUTH_EDX_OAUTH2_KEY = "replace-me"
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = "replace-me"
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = "replace-me"
+SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = "replace-me"
+BACKEND_SERVICE_EDX_OAUTH2_KEY = "replace-me"
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = "replace-me"
 
 JWT_AUTH = {
-    'JWT_AUTH_HEADER_PREFIX': 'JWT',
-    'JWT_ISSUER': 'http://127.0.0.1:8000/oauth2',
-    'JWT_ALGORITHM': 'HS256',
-    'JWT_VERIFY_EXPIRATION': True,
-    'JWT_PAYLOAD_GET_USERNAME_HANDLER': lambda d: d.get('preferred_username'),
-    'JWT_LEEWAY': 1,
-    'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
-    'JWT_PUBLIC_SIGNING_JWK_SET': None,
-    'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
-    'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
-    'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
+    "JWT_AUTH_HEADER_PREFIX": "JWT",
+    "JWT_ISSUER": "http://127.0.0.1:8000/oauth2",
+    "JWT_ALGORITHM": "HS256",
+    "JWT_VERIFY_EXPIRATION": True,
+    "JWT_PAYLOAD_GET_USERNAME_HANDLER": lambda d: d.get("preferred_username"),
+    "JWT_LEEWAY": 1,
+    "JWT_DECODE_HANDLER": "edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler",
+    "JWT_PUBLIC_SIGNING_JWK_SET": None,
+    "JWT_AUTH_COOKIE": "edx-jwt-cookie",
+    "JWT_AUTH_COOKIE_HEADER_PAYLOAD": "edx-jwt-cookie-header-payload",
+    "JWT_AUTH_COOKIE_SIGNATURE": "edx-jwt-cookie-signature",
 }
 
 # Carry fields from the JWT token and LMS user into the local user
@@ -238,15 +227,15 @@ EDX_DRF_EXTENSIONS = {
 }
 
 # Request the user's permissions in the ID token
-EXTRA_SCOPE = ['permissions']
+EXTRA_SCOPE = ["permissions"]
 
 # TODO Set this to another (non-staff, ideally) path.
-LOGIN_REDIRECT_URL = '/admin/'
+LOGIN_REDIRECT_URL = "/admin/"
 # END AUTHENTICATION CONFIGURATION
 
 
 # OPENEDX-SPECIFIC CONFIGURATION
-PLATFORM_NAME = 'Your Platform Name Here'
+PLATFORM_NAME = "Your Platform Name Here"
 # END OPENEDX-SPECIFIC CONFIGURATION
 
 # Set up logging for development use (logging to stdout)

--- a/program_intent_engagement/urls.py
+++ b/program_intent_engagement/urls.py
@@ -21,7 +21,8 @@ from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
-from rest_framework_swagger.views import get_swagger_view
+
+from rest_framework.schemas import get_schema_view
 
 from program_intent_engagement.apps.api import urls as api_urls
 from program_intent_engagement.apps.core import views as core_views
@@ -29,16 +30,24 @@ from program_intent_engagement.apps.core import views as core_views
 admin.autodiscover()
 
 urlpatterns = oauth2_urlpatterns + [
-    path('admin/', admin.site.urls),
-    path('api/', include(api_urls)),
-    path('api-docs/', get_swagger_view(title='program-intent-engagement API')),
-    path('auto_auth/', core_views.AutoAuth.as_view(), name='auto_auth'),
-    path('', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
-    path('health/', core_views.health, name='health'),
+    path("admin/", admin.site.urls),
+    path("api/", include(api_urls)),
+    path(
+        "api-docs/",
+        get_schema_view(
+            title="program-intent-engagement API",
+            description="API to review and modify a predicted intent to engage with the program",
+            public=True,
+        ),
+    ),
+    path("auto_auth/", core_views.AutoAuth.as_view(), name="auto_auth"),
+    path("", include("csrf.urls")),  # Include csrf urls from edx-drf-extensions
+    path("health/", core_views.health, name="health"),
 ]
 
-if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
+if settings.DEBUG and os.environ.get("ENABLE_DJANGO_TOOLBAR", False):  # pragma: no cover
     # Disable pylint import error because we don't install django-debug-toolbar
     # for CI build
     import debug_toolbar  # isort:skip pylint: disable=import-error,useless-suppression
-    urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))
+
+    urlpatterns.append(path("__debug__/", include(debug_toolbar.urls)))

--- a/program_intent_engagement/urls.py
+++ b/program_intent_engagement/urls.py
@@ -21,7 +21,6 @@ from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
-
 from rest_framework.schemas import get_schema_view
 
 from program_intent_engagement.apps.api import urls as api_urls

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,6 @@ Django         # Web application framework
 django-cors-headers
 django-extensions
 django-model-utils
-django-rest-swagger
 django-waffle
 djangorestframework
 edx-api-doc-tools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,12 +22,6 @@ click==8.2.1
     #   edx-django-utils
 code-annotations==2.3.0
     # via edx-toggles
-coreapi==2.3.3
-    # via
-    #   django-rest-swagger
-    #   openapi-codec
-coreschema==0.0.4
-    # via coreapi
 cryptography==45.0.6
     # via
     #   pyjwt
@@ -66,8 +60,6 @@ django-extensions==4.1
     # via -r requirements/base.in
 django-model-utils==5.0.0
     # via -r requirements/base.in
-django-rest-swagger==2.2.0
-    # via -r requirements/base.in
 django-waffle==5.0.0
     # via
     #   -r requirements/base.in
@@ -77,7 +69,6 @@ django-waffle==5.0.0
 djangorestframework==3.16.1
     # via
     #   -r requirements/base.in
-    #   django-rest-swagger
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
@@ -113,12 +104,8 @@ idna==3.10
     # via requests
 inflection==0.5.1
     # via drf-yasg
-itypes==1.2.0
-    # via coreapi
 jinja2==3.1.6
-    # via
-    #   code-annotations
-    #   coreschema
+    # via code-annotations
 markupsafe==3.0.2
     # via jinja2
 mysqlclient==2.2.7
@@ -127,12 +114,8 @@ oauthlib==3.3.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via django-rest-swagger
 packaging==25.0
     # via drf-yasg
-pbr==6.1.1
-    # via stevedore
 psutil==7.0.0
     # via edx-django-utils
 pycparser==2.22
@@ -144,7 +127,7 @@ pyjwt[crypto]==2.10.1
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==4.14.0
+pymongo==4.14.1
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -161,9 +144,8 @@ pyyaml==6.0.2
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
-requests==2.32.4
+requests==2.32.5
     # via
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
@@ -172,8 +154,6 @@ requests-oauthlib==2.0.0
     # via social-auth-core
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.20.1
-    # via django-rest-swagger
 six==1.17.0
     # via
     #   edx-auth-backends
@@ -186,19 +166,17 @@ social-auth-core==4.7.0
     #   social-auth-app-django
 sqlparse==0.5.3
     # via django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via edx-opaque-keys
 uritemplate==4.2.0
-    # via
-    #   coreapi
-    #   drf-yasg
+    # via drf-yasg
 urllib3==2.5.0
     # via requests
 

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-cachetools==6.1.0
+cachetools==6.2.0
     # via tox
 chardet==5.2.0
     # via tox
 colorama==0.4.6
     # via tox
-coverage==7.10.3
+coverage==7.10.5
     # via -r requirements/ci.in
 distlib==0.4.0
     # via virtualenv
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   tox
     #   virtualenv
@@ -32,5 +32,5 @@ pyproject-api==1.9.1
     # via tox
 tox==4.28.4
     # via -r requirements/ci.in
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ build==1.3.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==6.1.0
+cachetools==6.2.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -62,16 +62,7 @@ colorama==0.4.6
     # via
     #   -r requirements/validation.txt
     #   tox
-coreapi==2.3.3
-    # via
-    #   -r requirements/validation.txt
-    #   django-rest-swagger
-    #   openapi-codec
-coreschema==0.0.4
-    # via
-    #   -r requirements/validation.txt
-    #   coreapi
-coverage[toml]==7.10.3
+coverage[toml]==7.10.5
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -133,8 +124,6 @@ django-extensions==4.1
     # via -r requirements/validation.txt
 django-model-utils==5.0.0
     # via -r requirements/validation.txt
-django-rest-swagger==2.2.0
-    # via -r requirements/validation.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/validation.txt
@@ -144,7 +133,6 @@ django-waffle==5.0.0
 djangorestframework==3.16.1
     # via
     #   -r requirements/validation.txt
-    #   django-rest-swagger
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
@@ -200,7 +188,7 @@ faker==37.5.3
     # via
     #   -r requirements/validation.txt
     #   factory-boy
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -225,10 +213,6 @@ isort==6.0.1
     # via
     #   -r requirements/validation.txt
     #   pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/validation.txt
-    #   coreapi
 jaraco-classes==3.4.0
     # via
     #   -r requirements/validation.txt
@@ -237,7 +221,7 @@ jaraco-context==6.0.1
     # via
     #   -r requirements/validation.txt
     #   keyring
-jaraco-functools==4.2.1
+jaraco-functools==4.3.0
     # via
     #   -r requirements/validation.txt
     #   keyring
@@ -250,13 +234,12 @@ jinja2==3.1.6
     # via
     #   -r requirements/validation.txt
     #   code-annotations
-    #   coreschema
     #   diff-cover
 keyring==25.6.0
     # via
     #   -r requirements/validation.txt
     #   twine
-lxml[html-clean]==6.0.0
+lxml[html-clean]==6.0.1
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -296,10 +279,6 @@ oauthlib==3.3.1
     #   -r requirements/validation.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/validation.txt
-    #   django-rest-swagger
 packaging==25.0
     # via
     #   -r requirements/pip-tools.txt
@@ -312,10 +291,6 @@ packaging==25.0
     #   twine
 path==16.16.0
     # via edx-i18n-tools
-pbr==6.1.1
-    # via
-    #   -r requirements/validation.txt
-    #   stevedore
 pip-tools==7.5.0
     # via -r requirements/pip-tools.txt
 platformdirs==4.3.8
@@ -380,7 +355,7 @@ pylint-plugin-utils==0.9.0
     #   -r requirements/validation.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.0
+pymongo==4.14.1
     # via
     #   -r requirements/validation.txt
     #   edx-opaque-keys
@@ -429,10 +404,9 @@ readme-renderer==44.0
     # via
     #   -r requirements/validation.txt
     #   twine
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/validation.txt
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   id
@@ -464,10 +438,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-simplejson==3.20.1
-    # via
-    #   -r requirements/validation.txt
-    #   django-rest-swagger
 six==1.17.0
     # via
     #   -r requirements/validation.txt
@@ -492,7 +462,7 @@ sqlparse==0.5.3
     #   -r requirements/validation.txt
     #   django
     #   django-debug-toolbar
-stevedore==5.4.1
+stevedore==5.5.0
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -510,7 +480,7 @@ tox==4.28.4
     # via -r requirements/validation.txt
 twine==6.1.0
     # via -r requirements/validation.txt
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/validation.txt
     #   edx-opaque-keys
@@ -521,14 +491,13 @@ tzdata==2025.2
 uritemplate==4.2.0
     # via
     #   -r requirements/validation.txt
-    #   coreapi
     #   drf-yasg
 urllib3==2.5.0
     # via
     #   -r requirements/validation.txt
     #   requests
     #   twine
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via
     #   -r requirements/validation.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,11 +22,11 @@ babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.4
+beautifulsoup4==4.13.5
     # via pydata-sphinx-theme
 build==1.3.0
     # via -r requirements/doc.in
-cachetools==6.1.0
+cachetools==6.2.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -67,16 +67,7 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-coreapi==2.3.3
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
-    #   openapi-codec
-coreschema==0.0.4
-    # via
-    #   -r requirements/test.txt
-    #   coreapi
-coverage[toml]==7.10.3
+coverage[toml]==7.10.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -134,8 +125,6 @@ django-extensions==4.1
     # via -r requirements/test.txt
 django-model-utils==5.0.0
     # via -r requirements/test.txt
-django-rest-swagger==2.2.0
-    # via -r requirements/test.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/test.txt
@@ -145,7 +134,6 @@ django-waffle==5.0.0
 djangorestframework==3.16.1
     # via
     #   -r requirements/test.txt
-    #   django-rest-swagger
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
@@ -204,7 +192,7 @@ faker==37.5.3
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -229,15 +217,11 @@ isort==6.0.1
     # via
     #   -r requirements/test.txt
     #   pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/test.txt
-    #   coreapi
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.2.1
+jaraco-functools==4.3.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -247,7 +231,6 @@ jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
-    #   coreschema
     #   sphinx
 keyring==25.6.0
     # via twine
@@ -278,10 +261,6 @@ oauthlib==3.3.1
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 packaging==25.0
     # via
     #   -r requirements/test.txt
@@ -293,10 +272,6 @@ packaging==25.0
     #   sphinx
     #   tox
     #   twine
-pbr==6.1.1
-    # via
-    #   -r requirements/test.txt
-    #   stevedore
 platformdirs==4.3.8
     # via
     #   -r requirements/test.txt
@@ -357,7 +332,7 @@ pylint-plugin-utils==0.9.0
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.0
+pymongo==4.14.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -400,10 +375,9 @@ pyyaml==6.0.2
     #   edx-django-release-util
 readme-renderer==44.0
     # via twine
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/test.txt
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   id
@@ -432,10 +406,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.20.1
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 six==1.17.0
     # via
     #   -r requirements/test.txt
@@ -478,7 +448,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -497,7 +467,7 @@ tox==4.28.4
     # via -r requirements/test.txt
 twine==6.1.0
     # via -r requirements/doc.in
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
@@ -510,14 +480,13 @@ tzdata==2025.2
 uritemplate==4.2.0
     # via
     #   -r requirements/test.txt
-    #   coreapi
     #   drf-yasg
 urllib3==2.5.0
     # via
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -31,15 +31,6 @@ code-annotations==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
-coreapi==2.3.3
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
-    #   openapi-codec
-coreschema==0.0.4
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
 cryptography==45.0.6
     # via
     #   -r requirements/base.txt
@@ -79,8 +70,6 @@ django-extensions==4.1
     # via -r requirements/base.txt
 django-model-utils==5.0.0
     # via -r requirements/base.txt
-django-rest-swagger==2.2.0
-    # via -r requirements/base.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/base.txt
@@ -90,7 +79,6 @@ django-waffle==5.0.0
 djangorestframework==3.16.1
     # via
     #   -r requirements/base.txt
-    #   django-rest-swagger
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
@@ -146,15 +134,10 @@ inflection==0.5.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
-itypes==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
 jinja2==3.1.6
     # via
     #   -r requirements/base.txt
     #   code-annotations
-    #   coreschema
 markupsafe==3.0.2
     # via
     #   -r requirements/base.txt
@@ -168,19 +151,11 @@ oauthlib==3.3.1
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
 packaging==25.0
     # via
     #   -r requirements/base.txt
     #   drf-yasg
     #   gunicorn
-pbr==6.1.1
-    # via
-    #   -r requirements/base.txt
-    #   stevedore
 psutil==7.0.0
     # via
     #   -r requirements/base.txt
@@ -197,7 +172,7 @@ pyjwt[crypto]==2.10.1
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==4.14.0
+pymongo==4.14.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -226,10 +201,9 @@ pyyaml==6.0.2
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/base.txt
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
@@ -242,10 +216,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.20.1
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
 six==1.17.0
     # via
     #   -r requirements/base.txt
@@ -264,7 +234,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -274,14 +244,13 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
 uritemplate==4.2.0
     # via
     #   -r requirements/base.txt
-    #   coreapi
     #   drf-yasg
 urllib3==2.5.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,7 +14,7 @@ astroid==3.3.11
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-cachetools==6.1.0
+cachetools==6.2.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -55,16 +55,7 @@ colorama==0.4.6
     # via
     #   -r requirements/test.txt
     #   tox
-coreapi==2.3.3
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
-    #   openapi-codec
-coreschema==0.0.4
-    # via
-    #   -r requirements/test.txt
-    #   coreapi
-coverage[toml]==7.10.3
+coverage[toml]==7.10.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -122,8 +113,6 @@ django-extensions==4.1
     # via -r requirements/test.txt
 django-model-utils==5.0.0
     # via -r requirements/test.txt
-django-rest-swagger==2.2.0
-    # via -r requirements/test.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/test.txt
@@ -133,7 +122,6 @@ django-waffle==5.0.0
 djangorestframework==3.16.1
     # via
     #   -r requirements/test.txt
-    #   django-rest-swagger
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
@@ -187,7 +175,7 @@ faker==37.5.3
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -211,15 +199,11 @@ isort==6.0.1
     #   -r requirements/quality.in
     #   -r requirements/test.txt
     #   pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/test.txt
-    #   coreapi
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.2.1
+jaraco-functools==4.3.0
     # via keyring
 jeepney==0.9.0
     # via
@@ -229,7 +213,6 @@ jinja2==3.1.6
     # via
     #   -r requirements/test.txt
     #   code-annotations
-    #   coreschema
 keyring==25.6.0
     # via twine
 markdown-it-py==4.0.0
@@ -259,10 +242,6 @@ oauthlib==3.3.1
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 packaging==25.0
     # via
     #   -r requirements/test.txt
@@ -271,10 +250,6 @@ packaging==25.0
     #   pytest
     #   tox
     #   twine
-pbr==6.1.1
-    # via
-    #   -r requirements/test.txt
-    #   stevedore
 platformdirs==4.3.8
     # via
     #   -r requirements/test.txt
@@ -333,7 +308,7 @@ pylint-plugin-utils==0.9.0
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.0
+pymongo==4.14.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -374,10 +349,9 @@ pyyaml==6.0.2
     #   edx-django-release-util
 readme-renderer==44.0
     # via twine
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/test.txt
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   id
@@ -401,10 +375,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.20.1
-    # via
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 six==1.17.0
     # via
     #   -r requirements/test.txt
@@ -426,7 +396,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -444,7 +414,7 @@ tox==4.28.4
     # via -r requirements/test.txt
 twine==6.1.0
     # via -r requirements/quality.in
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -455,14 +425,13 @@ tzdata==2025.2
 uritemplate==4.2.0
     # via
     #   -r requirements/test.txt
-    #   coreapi
     #   drf-yasg
 urllib3==2.5.0
     # via
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,7 @@ astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
-cachetools==6.1.0
+cachetools==6.2.0
     # via tox
 certifi==2025.8.3
     # via
@@ -47,16 +47,7 @@ code-annotations==2.3.0
     #   edx-toggles
 colorama==0.4.6
     # via tox
-coreapi==2.3.3
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
-    #   openapi-codec
-coreschema==0.0.4
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
-coverage[toml]==7.10.3
+coverage[toml]==7.10.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -108,8 +99,6 @@ django-extensions==4.1
     # via -r requirements/base.txt
 django-model-utils==5.0.0
     # via -r requirements/base.txt
-django-rest-swagger==2.2.0
-    # via -r requirements/base.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/base.txt
@@ -119,7 +108,6 @@ django-waffle==5.0.0
 djangorestframework==3.16.1
     # via
     #   -r requirements/base.txt
-    #   django-rest-swagger
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
@@ -167,7 +155,7 @@ factory-boy==3.3.3
     # via -r requirements/test.in
 faker==37.5.3
     # via factory-boy
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   tox
     #   virtualenv
@@ -183,15 +171,10 @@ iniconfig==2.1.0
     # via pytest
 isort==6.0.1
     # via pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/base.txt
-    #   coreapi
 jinja2==3.1.6
     # via
     #   -r requirements/base.txt
     #   code-annotations
-    #   coreschema
 markupsafe==3.0.2
     # via
     #   -r requirements/base.txt
@@ -207,10 +190,6 @@ oauthlib==3.3.1
     #   -r requirements/base.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
 packaging==25.0
     # via
     #   -r requirements/base.txt
@@ -218,10 +197,6 @@ packaging==25.0
     #   pyproject-api
     #   pytest
     #   tox
-pbr==6.1.1
-    # via
-    #   -r requirements/base.txt
-    #   stevedore
 platformdirs==4.3.8
     # via
     #   pylint
@@ -264,7 +239,7 @@ pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.0
+pymongo==4.14.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -300,10 +275,9 @@ pyyaml==6.0.2
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/base.txt
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
@@ -316,10 +290,6 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.20.1
-    # via
-    #   -r requirements/base.txt
-    #   django-rest-swagger
 six==1.17.0
     # via
     #   -r requirements/base.txt
@@ -339,7 +309,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -353,7 +323,7 @@ tomlkit==0.13.3
     # via pylint
 tox==4.28.4
     # via -r requirements/test.in
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -362,13 +332,12 @@ tzdata==2025.2
 uritemplate==4.2.0
     # via
     #   -r requirements/base.txt
-    #   coreapi
     #   drf-yasg
 urllib3==2.5.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via tox
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -16,7 +16,7 @@ astroid==3.3.11
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-cachetools==6.1.0
+cachetools==6.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -66,18 +66,7 @@ colorama==0.4.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   tox
-coreapi==2.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   django-rest-swagger
-    #   openapi-codec
-coreschema==0.0.4
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   coreapi
-coverage[toml]==7.10.3
+coverage[toml]==7.10.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -150,10 +139,6 @@ django-model-utils==5.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-django-rest-swagger==2.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
 django-waffle==5.0.0
     # via
     #   -r requirements/quality.txt
@@ -165,7 +150,6 @@ djangorestframework==3.16.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   django-rest-swagger
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
@@ -240,7 +224,7 @@ faker==37.5.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -270,11 +254,6 @@ isort==6.0.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-itypes==1.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   coreapi
 jaraco-classes==3.4.0
     # via
     #   -r requirements/quality.txt
@@ -283,7 +262,7 @@ jaraco-context==6.0.1
     # via
     #   -r requirements/quality.txt
     #   keyring
-jaraco-functools==4.2.1
+jaraco-functools==4.3.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -297,7 +276,6 @@ jinja2==3.1.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   code-annotations
-    #   coreschema
 keyring==25.6.0
     # via
     #   -r requirements/quality.txt
@@ -343,11 +321,6 @@ oauthlib==3.3.1
     #   -r requirements/test.txt
     #   requests-oauthlib
     #   social-auth-core
-openapi-codec==1.3.2
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 packaging==25.0
     # via
     #   -r requirements/quality.txt
@@ -357,11 +330,6 @@ packaging==25.0
     #   pytest
     #   tox
     #   twine
-pbr==6.1.1
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   stevedore
 platformdirs==4.3.8
     # via
     #   -r requirements/quality.txt
@@ -430,7 +398,7 @@ pylint-plugin-utils==0.9.0
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.14.0
+pymongo==4.14.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -485,11 +453,10 @@ readme-renderer==44.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   id
@@ -523,11 +490,6 @@ semantic-version==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.20.1
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   django-rest-swagger
 six==1.17.0
     # via
     #   -r requirements/quality.txt
@@ -555,7 +517,7 @@ sqlparse==0.5.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -578,7 +540,7 @@ tox==4.28.4
     #   -r requirements/test.txt
 twine==6.1.0
     # via -r requirements/quality.txt
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -592,7 +554,6 @@ uritemplate==4.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   coreapi
     #   drf-yasg
 urllib3==2.5.0
     # via
@@ -600,7 +561,7 @@ urllib3==2.5.0
     #   -r requirements/test.txt
     #   requests
     #   twine
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
the switches to using DRF's native schema generation, because it has deprecated coreAPI:

https://www.django-rest-framework.org/community/3.10-announcement/

FIXES: APER-3932
